### PR TITLE
allow multiple symbols to dividend events endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,17 +40,17 @@ jobs:
     - name: Install system dependencies
       run: |
         make talib_windows_py37
-      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.7 }}
+      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.7 && (github.event_name == matrix.event-name || matrix.os == 'ubuntu-latest') }}
 
     - name: Install system dependencies
       run: |
         make talib_windows_py38
-      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.8 }}
+      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.8 && (github.event_name == matrix.event-name || matrix.os == 'ubuntu-latest') }}
 
     - name: Install system dependencies
       run: |
         make talib_windows_py39
-      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.9 }}
+      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.9 && (github.event_name == matrix.event-name || matrix.os == 'ubuntu-latest') }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,17 +40,17 @@ jobs:
     - name: Install system dependencies
       run: |
         make talib_windows_py37
-      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.7 && (github.event_name == matrix.event-name || matrix.os == 'ubuntu-latest') }}
+      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.7 }}
 
     - name: Install system dependencies
       run: |
         make talib_windows_py38
-      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.8 && (github.event_name == matrix.event-name || matrix.os == 'ubuntu-latest') }}
+      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.8 }}
 
     - name: Install system dependencies
       run: |
         make talib_windows_py39
-      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.9 && (github.event_name == matrix.event-name || matrix.os == 'ubuntu-latest') }}
+      if: ${{ matrix.os == 'windows-latest' && matrix.python-version == 3.9 }}
 
     - name: Install dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ talib_darwin:  ## install talib for mac
 	cd ta-lib && ./configure && make &&	make install
 
 talib_windows_py37:  ## install talib for windows
-	python -m pip install https://download.lfd.uci.edu/pythonlibs/r4tycu3t/TA_Lib-0.4.20-cp37-cp37m-win_amd64.whl
+	python -m pip install https://public.paine.nyc/TA_Lib-0.4.21-cp37-cp37m-win_amd64.whl
 
 talib_windows_py38:  ## install talib for windows
-	python -m pip install https://download.lfd.uci.edu/pythonlibs/r4tycu3t/TA_Lib-0.4.20-cp38-cp38-win_amd64.whl
+	python -m pip install https://public.paine.nyc/TA_Lib-0.4.21-cp38-cp38-win_amd64.whl
 
 talib_windows_py39:  ## install talib for windows
-	python -m pip install https://download.lfd.uci.edu/pythonlibs/r4tycu3t/TA_Lib-0.4.20-cp39-cp39-win_amd64.whl
+	python -m pip install https://public.paine.nyc/TA_Lib-0.4.21-cp39-cp39-win_amd64.whl
 
 annotate: ## MyPy type annotation check
 	python -m mypy -s pyEX

--- a/pyEX/common/checks.py
+++ b/pyEX/common/checks.py
@@ -400,8 +400,11 @@ _INDICATOR_RETURNS = {
 
 def _strToList(st):
     """internal"""
-    if isinstance(st, string_types):
+    st = st.strip()
+    if st and isinstance(st, string_types):
         return st.split(",")
+    elif st is None or isinstance(st, string_types):
+        return []
     return st
 
 

--- a/pyEX/common/checks.py
+++ b/pyEX/common/checks.py
@@ -518,7 +518,7 @@ def _quoteSymbols(symbols):
     """urlquote a potentially comma-separate list of symbols"""
     if isinstance(symbols, list):
         # comma separated, quote separately
-        return ",".join(quote(symbol, safe="") for symbol in symbols)
+        return ",".join(quote(symbol.strip(), safe="") for symbol in symbols)
     # not comma separated, just quote
     return quote(symbols, safe=",")
 

--- a/pyEX/common/checks.py
+++ b/pyEX/common/checks.py
@@ -400,9 +400,8 @@ _INDICATOR_RETURNS = {
 
 def _strToList(st):
     """internal"""
-    st = st.strip()
     if st and isinstance(st, string_types):
-        return st.split(",")
+        return st.strip().split(",")
     elif st is None or isinstance(st, string_types):
         return []
     return st

--- a/pyEX/stocks/events.py
+++ b/pyEX/stocks/events.py
@@ -11,11 +11,41 @@ import pandas as pd
 
 from ..common import (
     _get,
+    _strToList,
     _quoteSymbols,
     _raiseIfNotStr,
     _toDatetime,
     json_normalize,
 )
+
+
+def _baseEvent(
+    event="events",
+    symbol="",
+    exactDate="",
+    token="",
+    version="stable",
+    filter="",
+    format="json",
+):
+    symbol = _strToList(symbol)
+
+    if len(symbol) == 0:
+        # full market
+        url = "stock/market/upcoming-{}".format(event)
+    elif len(symbol) == 1:
+        # just 1 symbol
+        url = "stock/{}/upcoming-{}".format(_quoteSymbols(symbol), event)
+    else:
+        # many symbols
+        url = "stock/market/upcoming-{}?symbols={}".format(event, _quoteSymbols(symbol))
+
+    if exactDate and len(symbol) > 1:
+        url += "&exactDate={}".format(exactDate)
+    elif exactDate:
+        url += "?exactDate={}".format(exactDate)
+
+    return _get(url, token, version, filter)
 
 
 def upcomingEvents(
@@ -42,17 +72,15 @@ def upcomingEvents(
         dict or DataFrame: result
 
     """
-    _raiseIfNotStr(symbol)
-    symbol = _quoteSymbols(symbol)
-
-    if symbol:
-        url = "stock/{}/upcoming-events".format(symbol)
-    else:
-        url = "stock/market/upcoming-events"
-
-    if exactDate:
-        url += "?exactDate={}".format(exactDate)
-    return _get(url, token, version, filter)
+    return _baseEvent(
+        "events",
+        symbol=symbol,
+        exactDate=exactDate,
+        token=token,
+        version=version,
+        filter=filter,
+        format=format,
+    )
 
 
 def _upcomingToDF(upcoming):
@@ -91,16 +119,15 @@ def upcomingEarnings(
         dict or DataFrame: result
 
     """
-    _raiseIfNotStr(symbol)
-    symbol = _quoteSymbols(symbol)
-    if symbol:
-        url = "stock/{}/upcoming-earnings".format(symbol)
-    else:
-        url = "stock/market/upcoming-earnings"
-
-    if exactDate:
-        url += "?exactDate={}".format(exactDate)
-    return _get(url, token, version, filter)
+    return _baseEvent(
+        "earnings",
+        symbol=symbol,
+        exactDate=exactDate,
+        token=token,
+        version=version,
+        filter=filter,
+        format=format,
+    )
 
 
 @wraps(upcomingEarnings)
@@ -132,18 +159,15 @@ def upcomingDividends(
         dict or DataFrame: result
 
     """
-    _raiseIfNotStr(symbol)
-    symbol = _quoteSymbols(symbol)
-    if symbol and "," in symbol:
-        url = "stock/market/upcoming-dividends?symbols={}".format(symbol)
-    elif symbol:
-        url = "stock/{}/upcoming-dividends".format(symbol)
-    else:
-        url = "stock/market/upcoming-dividends"
-
-    if exactDate:
-        url += "?exactDate={}".format(exactDate)
-    return _get(url, token, version, filter)
+    return _baseEvent(
+        "dividends",
+        symbol=symbol,
+        exactDate=exactDate,
+        token=token,
+        version=version,
+        filter=filter,
+        format=format,
+    )
 
 
 @wraps(upcomingDividends)
@@ -175,16 +199,15 @@ def upcomingSplits(
         dict or DataFrame: result
 
     """
-    _raiseIfNotStr(symbol)
-    symbol = _quoteSymbols(symbol)
-    if symbol:
-        url = "stock/{}/upcoming-splits".format(symbol)
-    else:
-        url = "stock/market/upcoming-splits"
-
-    if exactDate:
-        url += "?exactDate={}".format(exactDate)
-    return _get(url, token, version, filter)
+    return _baseEvent(
+        "splits",
+        symbol=symbol,
+        exactDate=exactDate,
+        token=token,
+        version=version,
+        filter=filter,
+        format=format,
+    )
 
 
 @wraps(upcomingSplits)
@@ -216,16 +239,15 @@ def upcomingIPOs(
         dict or DataFrame: result
 
     """
-    _raiseIfNotStr(symbol)
-    symbol = _quoteSymbols(symbol)
-    if symbol:
-        url = "stock/{}/upcoming-ipos".format(symbol)
-    else:
-        url = "stock/market/upcoming-ipos"
-
-    if exactDate:
-        url += "?exactDate={}".format(exactDate)
-    return _get(url, token, version, filter)
+    return _baseEvent(
+        "ipos",
+        symbol=symbol,
+        exactDate=exactDate,
+        token=token,
+        version=version,
+        filter=filter,
+        format=format,
+    )
 
 
 @wraps(upcomingIPOs)

--- a/pyEX/stocks/events.py
+++ b/pyEX/stocks/events.py
@@ -134,7 +134,9 @@ def upcomingDividends(
     """
     _raiseIfNotStr(symbol)
     symbol = _quoteSymbols(symbol)
-    if symbol:
+    if symbol and "," in symbol:
+        url = "stock/market/upcoming-dividends?symbols={}".format(symbol)
+    elif symbol:
         url = "stock/{}/upcoming-dividends".format(symbol)
     else:
         url = "stock/market/upcoming-dividends"

--- a/pyEX/stocks/events.py
+++ b/pyEX/stocks/events.py
@@ -13,7 +13,6 @@ from ..common import (
     _get,
     _strToList,
     _quoteSymbols,
-    _raiseIfNotStr,
     _toDatetime,
     json_normalize,
 )

--- a/pyEX/tests/test_stocks.py
+++ b/pyEX/tests/test_stocks.py
@@ -1146,11 +1146,15 @@ class TestAll:
             upcomingSplits()
             upcomingIPOs()
             upcomingEvents(SYMBOL)
+            upcomingEvents(SYMBOLS)
             upcomingEarnings(SYMBOL)
+            upcomingEarnings(SYMBOLS)
             upcomingDividends(SYMBOL)
             upcomingDividends(SYMBOLS)
             upcomingSplits(SYMBOL)
+            upcomingSplits(SYMBOLS)
             upcomingIPOs(SYMBOL)
+            upcomingIPOs(SYMBOLS)
 
     def test_upcomingEventsDF(self):
         from pyEX import (

--- a/pyEX/tests/test_stocks.py
+++ b/pyEX/tests/test_stocks.py
@@ -14,6 +14,7 @@ import time
 from mock import MagicMock, patch
 
 SYMBOL = "aapl"
+SYMBOLS = "wmt, msft"
 
 atexit.register = MagicMock()
 pickle.dump = MagicMock()
@@ -1147,6 +1148,7 @@ class TestAll:
             upcomingEvents(SYMBOL)
             upcomingEarnings(SYMBOL)
             upcomingDividends(SYMBOL)
+            upcomingDividends(SYMBOLS)
             upcomingSplits(SYMBOL)
             upcomingIPOs(SYMBOL)
 
@@ -1170,5 +1172,6 @@ class TestAll:
             upcomingEventsDF(SYMBOL)
             upcomingEarningsDF(SYMBOL)
             upcomingDividendsDF(SYMBOL)
+            upcomingDividendsDF(SYMBOLS)
             upcomingSplitsDF(SYMBOL)
             upcomingIPOsDF(SYMBOL)


### PR DESCRIPTION
This adds support for passing a comma-separated string of symbols into the upcomingDividends endpoint. Passing a list might be more convenient but this seemed to require the least amount of code changes. If accepted I can also add it for other relevant endpoints. 

I added some testing but the logic inside the API call didn't appear to have testing implemented so didn't add any there.